### PR TITLE
switch user lookup to API v2

### DIFF
--- a/src/BirdsiteLive.Domain/BirdsiteLive.Domain.csproj
+++ b/src/BirdsiteLive.Domain/BirdsiteLive.Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BirdsiteLive.Moderation/BirdsiteLive.Moderation.csproj
+++ b/src/BirdsiteLive.Moderation/BirdsiteLive.Moderation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BirdsiteLive.Pipeline/BirdsiteLive.Pipeline.csproj
+++ b/src/BirdsiteLive.Pipeline/BirdsiteLive.Pipeline.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/BirdsiteLive.Twitter/BirdsiteLive.Twitter.csproj
+++ b/src/BirdsiteLive.Twitter/BirdsiteLive.Twitter.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
     <PackageReference Include="TweetinviAPI" Version="4.0.3" />
   </ItemGroup>
 

--- a/src/BirdsiteLive.Twitter/CachedTwitterService.cs
+++ b/src/BirdsiteLive.Twitter/CachedTwitterService.cs
@@ -47,11 +47,6 @@ namespace BirdsiteLive.Twitter
             return user;
         }
 
-        public bool IsUserApiRateLimited()
-        {
-            return _twitterService.IsUserApiRateLimited();
-        }
-
         public void PurgeUser(string username)
         {
             _userCache.Remove(username);

--- a/src/BirdsiteLive.Twitter/Tools/TwitterAuthenticationInitializer.cs
+++ b/src/BirdsiteLive.Twitter/Tools/TwitterAuthenticationInitializer.cs
@@ -1,15 +1,20 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Net;
+using System.Net.Http;
 using BirdsiteLive.Common.Settings;
 using Microsoft.Extensions.Logging;
 using Tweetinvi;
+using System.Net.Http.Headers;
+using System.Text.Json;
 
 namespace BirdsiteLive.Twitter.Tools
 {
     public interface ITwitterAuthenticationInitializer
     {
-        void EnsureAuthenticationIsInitialized();
+        Task EnsureAuthenticationIsInitialized();
+        String Token {get;}
     }
 
     public class TwitterAuthenticationInitializer : ITwitterAuthenticationInitializer
@@ -18,16 +23,23 @@ namespace BirdsiteLive.Twitter.Tools
         private readonly ILogger<TwitterAuthenticationInitializer> _logger;
         private static bool _initialized;
         private readonly SemaphoreSlim _semaphoregate = new SemaphoreSlim(1);
+        private readonly IHttpClientFactory _httpClientFactory;
+        private String _token;
+        public String Token { 
+            get { return _token; }
+        }
+
 
         #region Ctor
-        public TwitterAuthenticationInitializer(TwitterSettings settings, ILogger<TwitterAuthenticationInitializer> logger)
+        public TwitterAuthenticationInitializer(TwitterSettings settings, ILogger<TwitterAuthenticationInitializer> logger, IHttpClientFactory httpClientFactory)
         {
             _settings = settings;
             _logger = logger;
+            _httpClientFactory = httpClientFactory;
         }
         #endregion
 
-        public void EnsureAuthenticationIsInitialized()
+        public async Task EnsureAuthenticationIsInitialized()
         {
             if (_initialized) return;
             _semaphoregate.Wait();
@@ -35,7 +47,7 @@ namespace BirdsiteLive.Twitter.Tools
             try
             {
                 if (_initialized) return;
-                InitTwitterCredentials();
+                await InitTwitterCredentials();
             }
             finally
             {
@@ -43,20 +55,38 @@ namespace BirdsiteLive.Twitter.Tools
             }
         }
 
-        private void InitTwitterCredentials()
+        private async Task InitTwitterCredentials()
         {
             for (;;)
             {
                 try
                 {
                     Auth.SetApplicationOnlyCredentials(_settings.ConsumerKey, _settings.ConsumerSecret, true);
+
+                    using (var request = new HttpRequestMessage(new HttpMethod("POST"), "https://api.twitter.com/oauth2/token"))
+                    {
+                        var httpClient = _httpClientFactory.CreateClient();
+                        var base64authorization = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes(_settings.ConsumerKey + ":" + _settings.ConsumerSecret));
+                        request.Headers.TryAddWithoutValidation("Authorization", $"Basic {base64authorization}"); 
+
+                        request.Content = new StringContent("grant_type=client_credentials");
+                        request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/x-www-form-urlencoded"); 
+
+                        var httpResponse = await httpClient.SendAsync(request);
+
+                        var c = await httpResponse.Content.ReadAsStringAsync();
+                        httpResponse.EnsureSuccessStatusCode();
+                        var doc = JsonDocument.Parse(c);
+                        _token = doc.RootElement.GetProperty("access_token").GetString();
+                    }
+
                     _initialized = true;
                     return;
                 }
                 catch (Exception e)
                 {
                     _logger.LogError(e, "Twitter Authentication Failed");
-                    Thread.Sleep(250);
+                    await Task.Delay(250);
                 }
             }
         }


### PR DESCRIPTION
So I'm working on porting Birdsite to the v2 of the twitter API, because they are reticent about giving me v1 access. I got quite carried away in my branch with lots of changes and I realized the PR would be quite gnarly. So I'm splitting it up with user lookup being the first part. The code is in a working state at this commit and uses both v1 and v2 for different parts.

The only thing I found so far that is missing from v1 to v2 is user banners. I use the same image in both profile and banner and it looks okay, but I guess I could just remove the banner entirely.

 I have lots of things coming up in other PRs, including having retweet broadcast as proper Announce:
![image](https://user-images.githubusercontent.com/1014864/169168366-061ba67d-1a4f-42e3-93c7-95706c59c7b2.png)

Let me know what you think about this, I'm happy to do any changes!
